### PR TITLE
Refactor DataPreprocessor

### DIFF
--- a/detectron2/README.md
+++ b/detectron2/README.md
@@ -2,44 +2,30 @@
 
 Drone Lantana Detectors based on Detectron2
 
-## Training 
+## Quickstart 
 
-The docker container is setup for training. If the data is laid out in the following format
+* Discovery: discover the site tiff files and the main shp file 
+* Validation: validate the polygons intersect between the tiffs and the shp file 
+* Tiling: split up the tiff into tiled 'pngs'
+* Annotation Transformation: intersect the bounds of each tile with the main shp file and generate COCO annotations, clipping polygons where necessary 
+* Training: fine-tune detectron2 on the COCO annotations 
+* Infernce: run inference on new images 
+
+* Steps 1-4: Discovery, validation, tiling and COCO annotation transformation
 ```
-root_dir/
-├── val
-├── train/
-│   └── annotations.json
-│   └── imag1.png
-│ 
-├── test/
-│   └── annotations.json
-│   └── imag1.png
-...
+$ python main.py --root_dir ... --tile_output_dir ... --train_dir ... --val_dir ... 
 ```
 
-simply running the docker will run training. 
-```console 
-$ docker build -t detectron2:0.1 .
-$ docker run -d --rm --net host -v $(pwd):/app detectron2:0.1
+* Step 5: Train 
 ```
-To save the logs to file 
-```
-$ docker run -d --rm --net host -v $(pwd):/app detectron2:0.1 python model.py > training.log 2>&1
-```
-The checkpoints are saved  to `output/checkpoints`
-
-
-## Inference 
-
-If `train_data` is set to None/empty, the program runs inference against the images in `--inference_data` using the weights in `--weights_path`. 
-
-```
-$ docker run -it --rm --net host -v $(pwd):/app --entrypoint /bin/bash detectron2:0.1 
-$ python ./model.py --train_data "" --inference_data ./data/val/ --weights_path ./output/checkpoints/output/model_final.pth
+docker run -d --rm --net host -v $(pwd):/app detectron2:0.1
 ```
 
-The output is saved to `output/images`
+* Step 6: Inference 
+```
+docker run -it --rm --net host -v $(pwd):/app --entrypoint /bin/bash detectron2:0.1 
+$ python ./main.py --train_data "" --inference_data ./data/val/ --weights_path ./output/checkpoints/output/model_final.pth
+```
 
 ## Data Processing
 
@@ -74,8 +60,47 @@ app/
 
 Where the annotations are in `COCO` json format. 
 Once the validation is complete, you must manually copy the  data into the `train`, `val` and `test` dirs before training the model. 
-The validation script will also print out a list of classes, which you currently need to replace in the `model.py` file. 
+The validation script will also print out a list of classes, which you currently need to replace in the `main.py` file. 
 
+
+## Training 
+
+The docker container is setup for training. If the data is laid out in the following format
+```
+root_dir/
+├── val
+├── train/
+│   └── annotations.json
+│   └── imag1.png
+│ 
+├── test/
+│   └── annotations.json
+│   └── imag1.png
+...
+```
+
+simply running the docker will run training. 
+```console 
+$ docker build -t detectron2:0.1 .
+$ docker run -d --rm --net host -v $(pwd):/app detectron2:0.1
+```
+To save the logs to file 
+```
+$ docker run -d --rm --net host -v $(pwd):/app detectron2:0.1 python main.py > training.log 2>&1
+```
+The checkpoints are saved  to `output/checkpoints`
+
+
+## Inference 
+
+If `train_data` is set to None/empty, the program runs inference against the images in `--inference_data` using the weights in `--weights_path`. 
+
+```
+$ docker run -it --rm --net host -v $(pwd):/app --entrypoint /bin/bash detectron2:0.1 
+$ python ./main.py --train_data "" --inference_data ./data/val/ --weights_path ./output/checkpoints/output/model_final.pth
+```
+
+The output is saved to `output/images`
 
 ## Assets
 

--- a/detectron2/discovery.py
+++ b/detectron2/discovery.py
@@ -1,0 +1,59 @@
+"""Discover the relevant files for training from new datasets.
+
+Usage: 
+    source venv/bin/activate 
+    python3 main.py --root_dir /path/to/root/dir --log_level DEBUG
+"""
+
+import os
+import logging
+
+# Get module-level logger
+logger = logging.getLogger(__name__)
+
+
+class DataDiscovery:
+    def __init__(self, root_dir):
+        self.root_dir = root_dir
+        self.tiff_files = self._discover_tiffs()
+        self.shapefile = self._discover_shapefile()
+
+    def _discover_tiffs(self):
+        """Recursively find all site .tiff files under root_dir.
+
+        This function matches site directories with site.tiff files and ignores all other tiff files. Eg: 
+
+        /foo/bar/site_1/site_1.tiff
+        /foo/bar/site_1/Bamboo/bamboo_123.tiff
+        /foo/bar/site_1/Bamboo/bamboo.tiff
+
+        This function will return: 
+        /foo/bar/site_1/site_1.tiff
+        /foo/bar/site_1/Bamboo/bamboo.tiff
+        """
+        main_tiffs = []
+
+        for subdir, dirs, files in os.walk(self.root_dir):
+            dir_name_raw = os.path.basename(subdir)
+            dir_name_normalized = dir_name_raw.lower().replace(" ", "_")
+
+            for file in files:
+                if file.lower().endswith(".tiff"):
+                    file_stem = os.path.splitext(file)[0].lower()
+                    if file_stem == dir_name_normalized:
+                        main_tiffs.append(os.path.join(subdir, file))
+        return main_tiffs
+
+    def _discover_shapefile(self):
+        """Discover the first shapefile found in the root_dir."""
+        shp_files = [f for f in os.listdir(
+            self.root_dir) if f.endswith(".shp")]
+        if not shp_files:
+            raise FileNotFoundError(f"No shapefiles found in {self.root_dir}")
+        return os.path.join(self.root_dir, shp_files[0])
+
+    def get_discovery_results(self):
+        return {
+            "tiff_files": self.tiff_files,
+            "shapefile": self.shapefile
+        }

--- a/detectron2/main.py
+++ b/detectron2/main.py
@@ -3,7 +3,8 @@
 import argparse
 import logging
 import json
-from validation import DataPreprocessor
+from validation import DataValidator
+from discovery import DataDiscovery
 
 
 def setup_logger(log_level=logging.INFO):
@@ -29,6 +30,18 @@ def main():
         description="Validate new datasets before copying them into app/data")
     parser.add_argument("--root_dir", type=str, required=True,
                         help="Path to the root directory containing site directories")
+    # parser.add_argument("--tile_output_dir", type=str, required=True,
+    #                     help="Where to save tiles and intermediate JSON")
+    # parser.add_argument("--tile_size", type=int,
+    #                     default=512, help="Tile size in pixels")
+    # parser.add_argument("--overlap", type=int, default=128,
+    #                     help="Overlap between tiles in pixels")
+    # parser.add_argument("--train_dir", type=str, required=True,
+    #                     help="Path to write train images and annotation")
+    # parser.add_argument("--val_dir", type=str, required=True,
+    #                     help="Path to write val images and annotation")
+    # parser.add_argument("--val_split", type=float, default=0.2,
+    #                     help="Fraction for validation split")
     parser.add_argument("--log_level", type=str, default="INFO",
                         choices=["INFO", "DEBUG",
                                  "WARNING", "ERROR", "CRITICAL"],
@@ -39,18 +52,18 @@ def main():
     # Setup logging at application start
     setup_logger(getattr(logging, args.log_level.upper()))
 
-    # Initialize the preprocessor
-    preprocessor = DataPreprocessor(args.root_dir)
+    # Discovery
+    discovery = DataDiscovery(args.root_dir)
+    discovery_results = discovery.get_discovery_results()
 
-    # Run validation
-    results = preprocessor.validate()
+    # Validation
+    validator = DataValidator(discovery_results)
+    validation_results = validator.validate()
     print("\nValidation Results:")
-    print(json.dumps(results, indent=2))
+    print(json.dumps(validation_results, indent=2))
 
-    # Get class information
-    classes = preprocessor.get_classes()
     print("\nClass Distribution:")
-    print(classes)
+    print(validator.get_classes())
 
 
 if __name__ == "__main__":

--- a/detectron2/validation.py
+++ b/detectron2/validation.py
@@ -1,10 +1,10 @@
 """Validate new datasets and extract classes by intersecting polygons. 
 
-1. Walk through directories starting from root_dir. 
-2. For every tiff found, read it's bounding box 
-3. Look through every polygon in the shp file for intersecting polygons 
-4. For each intersecting polygon, register the class name as belonging to that site 
-5. Print a summary 
+This scripts works on the output of the discovery script. 
+
+1. For every tiff discovered, read it's bounding box. 
+2. Look through every polygon in the discovered shp file for intersecting polygons 
+3. For each intersecting polygon, register the class name as belonging to that site 
 
 Usage: 
     source venv/bin/activate 
@@ -22,53 +22,17 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class DataPreprocessor:
-    def __init__(self, root_dir):
-        self.root_dir = root_dir
+class DataValidator:
+    def __init__(self, discovery_results):
+        self.tiff_files = discovery_results["tiff_files"]
+        self.shapefile = discovery_results["shapefile"]
+        self.gdf = gpd.read_file(self.shapefile)
         self.results = []
         self.all_classes = {}
-        self._load_shapefile()
-        self.tiff_files = self._discover_tiffs()
-
-    def _load_shapefile(self):
-        """Load the first shapefile found in the root_dir."""
-        shp_files = [f for f in os.listdir(
-            self.root_dir) if f.endswith(".shp")]
-        if not shp_files:
-            raise FileNotFoundError(f"No shapefiles found in {self.root_dir}")
-
-        self.base_shp = os.path.join(self.root_dir, shp_files[0])
-        self.gdf = gpd.read_file(self.base_shp)
-
-    def _discover_tiffs(self):
-        """Recursively find all site .tiff files under root_dir.
-
-        This function matches site directories with site.tiff files and ignores all other tiff files. Eg: 
-
-        /foo/bar/site_1/site_1.tiff
-        /foo/bar/site_1/Bamboo/bamboo_123.tiff
-        /foo/bar/site_1/Bamboo/bamboo.tiff
-
-        This function will return: 
-        /foo/bar/site_1/site_1.tiff
-        /foo/bar/site_1/Bamboo/bamboo.tiff
-        """
-        main_tiffs = []
-
-        for subdir, dirs, files in os.walk(self.root_dir):
-            dir_name_raw = os.path.basename(subdir)
-            dir_name_normalized = dir_name_raw.lower().replace(" ", "_")
-
-            for file in files:
-                if file.lower().endswith(".tiff"):
-                    file_stem = os.path.splitext(file)[0].lower()
-                    if file_stem == dir_name_normalized:
-                        main_tiffs.append(os.path.join(subdir, file))
-        return main_tiffs
 
     def _process_tiff(self, tiff_path):
         """For a given TIFF, find intersecting  polygons and return site info."""
-        rel_path = os.path.relpath(tiff_path, self.root_dir)
+        rel_path = os.path.relpath(tiff_path, os.path.dirname(self.shapefile))
 
         try:
             with rasterio.open(tiff_path) as src:


### PR DESCRIPTION
Split out data discovery and validation so we can keep the pipeline decoupled. That way the same discovery algorithm can be used in different pipelines, just like the same validation can be used with a different discovery (i.e as long as the same json input can be given to the validator, even if the directory structure is different, we can validate the input dataset the same way.

Currently the expectation is as follows:
`--root_dir`
```
some.shp
some_related.dbf,prj etc
dir1/
  site1/
    irrelevant_dir1/
    bamboo(irrelevant_dir2)/
    site1.tiff --> this needs to intersect the polygons in some.shp
  site2/
    site2.tiff --> this needs to intersect the polygons in some.shp
  site3/...
```
* The discovery class with create a json that has the shp file and the site.tiff files.
* The validation class will take json that has a pointer the the main shp file as well as a list of tiff files, and ensure that the bounds of each tiff intersect with polygons in the shp file
* The validation class also returns the total classes:counts in these intersecting polygons

There is no data transformation. All the validation script does is make sure the data in the tiffs matches the data in the shp, for if this is not true, all subsequent stages will fail.