### PR TITLE
Raise ValidationExceptions

### DIFF
--- a/detectron2/discovery.py
+++ b/detectron2/discovery.py
@@ -1,22 +1,35 @@
 """Discover the relevant files for training from new datasets.
 
 Usage: 
-    source venv/bin/activate 
-    python3 main.py --root_dir /path/to/root/dir --log_level DEBUG
+    DataDiscovery(root_dir).get_discovery_results()
 """
 
 import os
 import logging
+import geopandas as gpd
 
 # Get module-level logger
 logger = logging.getLogger(__name__)
 
 
 class DataDiscovery:
-    def __init__(self, root_dir):
+    """Discover the relevant files for training from new datasets.
+
+    @param root_dir: The root directory to search for data.
+    @param name_key: The key in the shapefile that contains the class names.
+
+    @return: A dictionary with the following keys:
+        - tiff_files: A list of paths to the site .tiff files.
+        - shapefile: The path to the shapefile.
+        - classes: A list of class names.   
+    """
+
+    def __init__(self, root_dir, name_key="Name"):
         self.root_dir = root_dir
         self.tiff_files = self._discover_tiffs()
         self.shapefile = self._discover_shapefile()
+        self.name_key = name_key
+        self.classes = self._discover_classes()
 
     def _discover_tiffs(self):
         """Recursively find all site .tiff files under root_dir.
@@ -52,8 +65,18 @@ class DataDiscovery:
             raise FileNotFoundError(f"No shapefiles found in {self.root_dir}")
         return os.path.join(self.root_dir, shp_files[0])
 
+    def _discover_classes(self):
+        """Discover the classes in the shapefile."""
+        gdf = gpd.read_file(self.shapefile)
+        if self.name_key not in gdf.columns:
+            raise ValueError(
+                f"Shapefile {self.shapefile} does not contain a {self.name_key} column")
+        return sorted(gdf[self.name_key].dropna().unique().tolist())
+
     def get_discovery_results(self):
         return {
             "tiff_files": self.tiff_files,
-            "shapefile": self.shapefile
+            "shapefile": self.shapefile,
+            "classes": self.classes,
+            "name_key": self.name_key
         }

--- a/detectron2/main.py
+++ b/detectron2/main.py
@@ -30,6 +30,8 @@ def main():
         description="Validate new datasets before copying them into app/data")
     parser.add_argument("--root_dir", type=str, required=True,
                         help="Path to the root directory containing site directories")
+    parser.add_argument("--name_key", type=str, default="Name",
+                        help="The key in the shapefile that contains the class names")
     # parser.add_argument("--tile_output_dir", type=str, required=True,
     #                     help="Where to save tiles and intermediate JSON")
     # parser.add_argument("--tile_size", type=int,
@@ -53,17 +55,18 @@ def main():
     setup_logger(getattr(logging, args.log_level.upper()))
 
     # Discovery
-    discovery = DataDiscovery(args.root_dir)
+    discovery = DataDiscovery(args.root_dir, args.name_key)
     discovery_results = discovery.get_discovery_results()
+    logging.debug("\nDiscovery Results:")
+    logging.info(json.dumps(discovery_results, indent=2))
 
     # Validation
     validator = DataValidator(discovery_results)
     validation_results = validator.validate()
-    print("\nValidation Results:")
-    print(json.dumps(validation_results, indent=2))
-
-    print("\nClass Distribution:")
-    print(validator.get_classes())
+    logging.debug("\nValidation Results:")
+    logging.debug(json.dumps(validation_results, indent=2))
+    logging.debug("\nClass Distribution:")
+    logging.debug(validator.get_classes())
 
 
 if __name__ == "__main__":

--- a/detectron2/validation.py
+++ b/detectron2/validation.py
@@ -17,15 +17,36 @@ import rasterio
 from shapely.geometry import box
 import fiona
 import logging
+from exceptions import InputException
+from exceptions import ValidationException
 
 # Get module-level logger
 logger = logging.getLogger(__name__)
 
 
 class DataValidator:
+    """Validate the dataset and collect class information.
+
+    @param discovery_results: The output of the discovery script.
+
+    @return: A list of dictionaries with the following keys:
+        - site: The relative path to the site file.
+        - area: The area of the site taken from the bounding box of the TIFF. 
+        - classes: A dictionary with the class name as the key and the count as the value, of all the classes found in the TIFF (i.e all the intersecting polygons with the shp file and the TIFF perimeter).
+
+    @raises: 
+        - InputError: If the discovery results are not valid.
+        - ValidationError: If no classes are found in the TIFFs, i.e no TIFF intersects with the shp file. This indicates a mismatch somewhere, either in the crs, or the sites and the shp file. 
+    """
+
     def __init__(self, discovery_results):
-        self.tiff_files = discovery_results["tiff_files"]
-        self.shapefile = discovery_results["shapefile"]
+        try:
+            self.tiff_files = discovery_results["tiff_files"]
+            self.shapefile = discovery_results["shapefile"]
+            self.name_key = discovery_results["name_key"]
+        except KeyError as e:
+            raise InputException(f"Invalid discovery results: {e}")
+
         self.gdf = gpd.read_file(self.shapefile)
         self.results = []
         self.all_classes = {}
@@ -49,10 +70,12 @@ class DataValidator:
                     tiff_polygon)]
 
                 if not intersecting.empty:
-                    class_counts = intersecting['Name'].value_counts(
+                    class_counts = intersecting[self.name_key].value_counts(
                     ).to_dict()
                 else:
                     class_counts = {}
+                    logging.warning(
+                        f"No intersecting polygons found for {tiff_path}")
 
                 area = tiff_polygon.area
 
@@ -84,6 +107,10 @@ class DataValidator:
                 for class_name, count in site_info['classes'].items():
                     self.all_classes[class_name] = self.all_classes.get(
                         class_name, 0) + count
+
+        if not any('classes' in result and result['classes']
+                   for result in self.results):
+            raise ValidationException("No classes found in validation results")
 
         return self.results
 


### PR DESCRIPTION
1. Pass the name_key through discovery and validation. The name_key is taken from the user and represents the name under which the class labels are stored in the shp file.

2. Raise a ValidationException if there is no intersection between the shp file and any of the site tiff files. This indicates a mismatch in CRS or that the data set is corrupted in some way.

Why raise validation errors? rather than train the model with a corrupted dataset, we want to stop and draw attention to the mismatch.

Opened https://github.com/bprashanth/dlt/issues/8 to deal with partial mismatch of tiff x shp files.