### PR TITLE
Teach the coco validation script to validate better

### DIFF
--- a/detectron2/coco.py
+++ b/detectron2/coco.py
@@ -12,8 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 class CocoHelper:
-    def __init__(self, coco_path):
+    def __init__(self, coco_path, focus_label=None):
         self.coco_path = coco_path
+        self.focus_label = focus_label
         self._load()
 
     def validate_segmentations(self):
@@ -39,6 +40,109 @@ class CocoHelper:
 
         return errors
 
+    def _validate_annotations(self):
+        anns_by_image = {}
+        for ann in self.data['annotations']:
+            anns_by_image.setdefault(ann["image_id"], []).append(ann)
+
+        cat_ids = set(cat['id'] for cat in self.categories)
+        focus_cat_id = self._cat_name_to_id.get(
+            self.focus_label) if self.focus_label else None
+
+        images_missing_anns = []
+        images_with_invalid_cats = []
+        images_with_malformed_anns = []
+        images_missing_focus = []
+
+        for img in self.data['images']:
+            img_id = img['id']
+            anns = anns_by_image.get(img_id, [])
+
+            if len(anns) == 0:
+                images_missing_anns.append(img_id)
+                continue
+
+            has_focus = False
+            for ann in anns:
+                # Bad category ID
+                if ann["category_id"] not in cat_ids:
+                    images_with_invalid_cats.append(img_id)
+                    break
+
+                # Empty bbox of malformed segmentation
+                if (not ann.get("bbox") or
+                    len(ann["bbox"]) != 4 or
+                    ann["bbox"][2] <= 0 or
+                        ann["bbox"][3] <= 0):
+
+                    images_with_malformed_anns.append(img_id)
+                    break
+
+                seg = ann.get("segmentation")
+                if (not isinstance(seg, list) or
+                    not seg or not isinstance(seg[0], list) or
+                        len(seg[0]) < 6):
+
+                    images_with_malformed_anns.append(img_id)
+                    break
+
+                if focus_cat_id is not None and ann["category_id"] == focus_cat_id:
+                    has_focus = True
+
+            if focus_cat_id is not None and not has_focus:
+                images_missing_focus.append(img_id)
+
+        # These are not errors per se, just that there are images in the
+        # input dataset that don't have any annotations whatsoever and images
+        # that don't have the focus label (so they effectively won't be used).
+        # NB: when using focus_label to generate annotations, this list turns
+        # into the focus_label list because we just have a bunch of images that
+        # don't have the focus (or any other) label.
+        if len(images_missing_anns) > 0:
+            logger.warning(
+                f"{len(images_missing_anns)} image(s) have no annotations and will be ignored.")
+            for img_id in images_missing_anns:
+                img_data = next(
+                    (img for img in self.data['images'] if img['id'] == img_id), None)
+                filename = img_data.get(
+                    'file_name', 'unknown') if img_data else 'unknown'
+                logger.debug(f"Image ID: {img_id}, File: {filename}")
+
+        if self.focus_label and len(images_missing_focus) > 0:
+            # This is not an error per se, just that there are images in the
+            # input dataset that don't have the focus label
+            logger.warning(
+                f"{len(images_missing_focus)} image(s) do not have any annotation with class '{self.focus_label}'.")
+            for img_id in images_missing_focus:
+                img_data = next(
+                    (img for img in self.data['images'] if img['id'] == img_id), None)
+                filename = img_data.get(
+                    'file_name', 'unknown') if img_data else 'unknown'
+                logger.debug(f"Image ID: {img_id}, File: {filename}")
+
+        errors = []
+        if len(images_with_invalid_cats) > 0:
+            errors.append(
+                f"{len(images_with_invalid_cats)} image(s) have annotations with unknown category IDs.")
+            for img_id in images_with_invalid_cats:
+                img_data = next(
+                    (img for img in self.data['images'] if img['id'] == img_id), None)
+                filename = img_data.get(
+                    'file_name', 'unknown') if img_data else 'unknown'
+                errors.append(f"Image ID: {img_id}, File: {filename}")
+
+        if len(images_with_malformed_anns) > 0:
+            errors.append(
+                f"{len(images_with_malformed_anns)} image(s) have malformed segmentations or empty bounding boxes.")
+            for img_id in images_with_malformed_anns:
+                img_data = next(
+                    (img for img in self.data['images'] if img['id'] == img_id), None)
+                filename = img_data.get(
+                    'file_name', 'unknown') if img_data else 'unknown'
+                errors.append(f"Image ID: {img_id}, File: {filename}")
+
+        return errors
+
     def _load(self):
         with open(self.coco_path, 'r') as f:
             self.data = json.load(f)
@@ -60,11 +164,6 @@ class CocoHelper:
         assert 'annotations' in self.data, "COCO file missing 'annotations'"
         assert 'categories' in self.data, "COCO file missing 'categories'"
 
-        errors = self.validate_segmentations()
-        if errors:
-            raise ValueError(
-                f"Segmentation validation failed with {len(errors)} errors:\n" + "\n".join(errors[:5]))
-
         # Extract classes in order
         self.categories = sorted(
             self.data['categories'], key=lambda x: x['id'])
@@ -78,6 +177,18 @@ class CocoHelper:
         self.class_names = [cat['name'] for cat in self.categories]
         self.class_id_map = {cat['id']: i for i,
                              cat in enumerate(self.categories)}
+        self._cat_name_to_id = {
+            cat['name']: cat['id'] for cat in self.categories}
+
+        errors = self.validate_segmentations()
+        if errors:
+            raise ValueError(
+                f"Segmentation validation failed with {len(errors)} errors:\n" + "\n".join(errors[:5]))
+
+        errors = self._validate_annotations()
+        if errors:
+            raise ValueError(
+                f"Annotation validation failed with {len(errors)} errors:\n" + "\n".join(errors[:5]))
 
     def get_class_names(self):
         return self.class_names

--- a/detectron2/docs/data.md
+++ b/detectron2/docs/data.md
@@ -2,7 +2,7 @@
 
 * Viewing the annotations laid over the tiff
 ```
-$ python3 ./hack/shp_on_tiff.py --tiff /home/desinotorious/rtmp/data/shola/data/Master_Labelled/Hossur\ Geratti\ 1/Hossur_Geratti_1.tiff --shp /home/desinotorious/rtmp/data/shola/data/Labels_Polygons_All.sh
+$ python3 ./hack/shp_on_tiff.py --tiff /home/desinotorious/rtmp/data/shola/data/Master_Labelled/Hossur\ Geratti\ 1/Hossur_Geratti_1.tiff --shp /home/desinotorious/rtmp/data/shola/data/Labels_Polygons_All.shp
 ```
 * To see if these annotations intersect with a tile in the final coco annotation run 
 ```

--- a/detectron2/hack/validate_coco.py
+++ b/detectron2/hack/validate_coco.py
@@ -35,10 +35,10 @@ def setup_logger(log_level=logging.INFO):
 
 
 
-def validate_coco_file(coco_path):
+def validate_coco_file(coco_path, focus_label=None):
     try:
         # This will automatically validate the file when loading
-        coco_helper = CocoHelper(coco_path)
+        coco_helper = CocoHelper(coco_path, focus_label=focus_label)
 
         # Print some statistics
         logging.info(f"Validation successful!")
@@ -60,12 +60,14 @@ def main():
                         help="Path to COCO annotation JSON file")
     parser.add_argument("--log_level", type=str, default="INFO",
                         choices=["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"])
+    parser.add_argument("--focus_field", type=str, default="Lantana camara",
+                        help="Field to focus on for validation")
     args = parser.parse_args()
 
     setup_logger(getattr(logging, args.log_level.upper()))
 
     logging.info(f"Validating COCO file: {args.coco}")
-    success = validate_coco_file(args.coco)
+    success = validate_coco_file(args.coco, args.focus_field)
 
     if not success:
         sys.exit(1)

--- a/detectron2/main.py
+++ b/detectron2/main.py
@@ -29,7 +29,7 @@ def setup_logger(log_level=logging.INFO):
     root_logger.setLevel(log_level)
 
 
-def launch_training_in_docker(train_dir, val_dir, output_dir, training_image, log_level):
+def launch_training_in_docker(train_dir, val_dir, output_dir, training_image, focus_label, log_level):
     client = docker.from_env()
 
     # TODO(prashanth@): There is a big assumption here around the working
@@ -42,6 +42,7 @@ def launch_training_in_docker(train_dir, val_dir, output_dir, training_image, lo
             "--train_dir", train_dir,
             "--val_dir", val_dir,
             "--output_dir", output_dir,
+            "--focus_label", focus_label,
             "--log_level", log_level
         ],
         volumes={
@@ -188,6 +189,7 @@ def main():
             args.val_dir,
             args.checkpoint_output_dir,
             args.training_image,
+            args.focus_label,
             args.log_level
         )
     else:

--- a/detectron2/trainer.py
+++ b/detectron2/trainer.py
@@ -29,7 +29,8 @@ def setup_logger(log_level=logging.INFO):
 
 
 class Trainer:
-    def __init__(self, train_dir, val_dir, output_dir, logger=None):
+    def __init__(
+            self, train_dir, val_dir, output_dir, focus_label=None, logger=None):
         self.train_dir = train_dir
         self.val_dir = val_dir
         self.output_dir = output_dir
@@ -41,8 +42,10 @@ class Trainer:
         self.train_coco_path = os.path.join(self.train_dir, "annotations.json")
         self.val_coco_path = os.path.join(self.val_dir, "annotations.json")
 
-        self.train_coco = CocoHelper(self.train_coco_path)
-        self.val_coco = CocoHelper(self.val_coco_path)
+        self.train_coco = CocoHelper(
+            self.train_coco_path, focus_label=focus_label)
+        self.val_coco = CocoHelper(
+            self.val_coco_path, focus_label=focus_label)
 
     def _register_datasets(self):
 
@@ -110,6 +113,8 @@ def main():
                         default="output", help="Path for model output")
     parser.add_argument("--log_level", type=str, default="INFO",
                         choices=["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"])
+    parser.add_argument("--focus_label", type=str, default="Lantana camara",
+                        help="Field to focus on for validation")
     args = parser.parse_args()
 
     setup_logger(getattr(logging, args.log_level.upper()))
@@ -121,7 +126,8 @@ def main():
         log_level: {args.log_level}\n\
     ")
 
-    trainer = Trainer(args.train_dir, args.val_dir, args.output_dir)
+    trainer = Trainer(args.train_dir, args.val_dir,
+                      args.output_dir, args.focus_label)
     checkpoint_path = trainer.train()
     logging.info(f"Training completed and model saved to {checkpoint_path}")
 


### PR DESCRIPTION
4 categories of new validation
1. ID mismatch between declared categories and image categories
2. Malformed annotations (eg malformed polygons)
3. WARNING: No annotations in image (auto discarded by detectron2)
4. WARNING: No focus_label in image (also auto discarded by d2 - because of the way we generate annotations)

The idea is if we observe a huge number of images getting lost in this process, we need to do something about it. Run this script *after* the `annotation_builder` stage to detect anomalies
```
$ python3 ./hack/validate_coco.py --coco data/train/annotations.json --log_level DEBUG --focus_field "Lantana camara"
```