### PR TITLE
Tune MAX_ITER

### DIFF
--- a/detectron2/coco.py
+++ b/detectron2/coco.py
@@ -198,3 +198,9 @@ class CocoHelper:
 
     def get_num_classes(self):
         return len(self.class_names)
+
+    def get_num_images(self):
+        return len(self.data['images'])
+
+    def get_num_annotations(self):
+        return len(self.data['annotations'])

--- a/detectron2/trainer.py
+++ b/detectron2/trainer.py
@@ -77,7 +77,16 @@ class Trainer:
         cfg.MODEL.ROI_HEADS.NUM_CLASSES = self.train_coco.get_num_classes()
         cfg.SOLVER.IMS_PER_BATCH = 2
         cfg.SOLVER.BASE_LR = 0.00025
-        cfg.SOLVER.MAX_ITER = 1000
+
+        # Desired epochs chosen artibrarily from literature
+        desired_epochs = 50
+        cfg.SOLVER.MAX_ITER = desired_epochs * (
+            self.train_coco.get_num_images() // cfg.SOLVER.IMS_PER_BATCH
+        )
+
+        # Tune this based on the loss curve, right now we're assuming that 200
+        # ish images is a "small" enough dataset that the decay won't make a
+        # huge difference
         cfg.SOLVER.STEPS = []
         cfg.MODEL.ROI_HEADS.BATCH_SIZE_PER_IMAGE = 256
         cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = 0.5


### PR DESCRIPTION
The max iter parametr needs to be set based on the number of training images. Previously hardcoded to 1000, currently, based on some assumptions from literature, updated to a dynamic number.