### PR TITLE
Generate "invalid" tiles

### DIFF
--- a/detectron2/annotation/annotation_builder.py
+++ b/detectron2/annotation/annotation_builder.py
@@ -64,6 +64,7 @@ class AnnotationBuilder:
             test_split=0.1,
             seed=42,
             focus_label=None,
+            # HACK: only for debugging, to process a single file.
             no_tile=False
     ):
         try:
@@ -80,6 +81,10 @@ class AnnotationBuilder:
         self.no_tile = no_tile
 
         # HACK: This is only for debugging, and is only used when no_tile=True.
+        # This is used as a debugging hack to process a single tile. Set
+        # no_tile=True and file_name_hack to the name of the tile you want to
+        # process, and all tiles in the tile_metadata.json file will be ignored
+        # except for the given file_name.
         if no_tile:
             self.file_name_hack = "Hossur_Geratti_1.png"
 
@@ -105,12 +110,13 @@ class AnnotationBuilder:
         except Exception as e:
             raise ValueError(f"Error opening tile {tile_path}: {e}")
 
-    def should_process_file(self, filename):
+    def should_process_file(self, tile):
         """Determine if a file should be processed based on no_tile and file_name_hack settings.
 
         @param filename: The name of the file to check
         @returns bool: True if the file should be processed, False otherwise
         """
+        filename = tile["filename"]
         if self.no_tile and self.file_name_hack:
             if (filename == self.file_name_hack):
                 logger.info(f"Processing file: {filename}")
@@ -118,7 +124,9 @@ class AnnotationBuilder:
             else:
                 logger.info(f"Skipping file: {filename}")
                 return False
-        return True
+        # TODO(dlt/issues/37): consolidate key names with
+        # tile_generator.
+        return tile.get("is_valid", True)
 
     def run(self):
         """Build annotations and save to disk.
@@ -140,7 +148,7 @@ class AnnotationBuilder:
         # Filter metadata before splitting
         # HACK: remove
         tile_metadata = [tile for tile in tile_metadata
-                         if self.should_process_file(tile["filename"])]
+                         if self.should_process_file(tile)]
 
         if not tile_metadata:
             raise ValueError("No files to process after filtering")

--- a/detectron2/main.py
+++ b/detectron2/main.py
@@ -191,6 +191,12 @@ def main():
     if not pipeline_config.get('skip_tiling', False):
         logging.info(f"Step 3: Tile Generation")
         # Calculate overlap in pixels from percentage
+        # Since pull/35, we are using percentage overlap instead of pixels.
+        # This could be a sort of "breaking change", meaning if you have
+        # inference plots generated with the old overlap number, and you rerun
+        # tiling, you will not be able to stitch the inference tiles back
+        # together with the new tile_metadata.json file.
+        # Hence, the rerun tiling with the old values, set output=128.
         overlap_pixels = int((args.overlap / 100.0) * args.tile_size)
         tile_generator = TileGenerator(
             discovery_results,

--- a/detectron2/tiling/tile_generator.py
+++ b/detectron2/tiling/tile_generator.py
@@ -184,7 +184,6 @@ class TileGenerator:
 
                     if not self._is_tile_valid(tile_mask):
                         skipped_tiles.append(tile_filename)
-                        continue
 
                     # Overwrite existing tiles.
                     # Since we are writing to PNG, rasterio will also supply a .
@@ -212,6 +211,7 @@ class TileGenerator:
                         "tile_bounds": list(tile_bounds),
                         "pixel_origin": [x, y],
                         "crs": crs.to_string(),
+                        "is_valid": tile_filename not in skipped_tiles
                     })
 
         if skipped_tiles:


### PR DESCRIPTION
Previously if the % of image in a cropped tile was too low w would skip it. However this creates problems for the final restitching back into a mosaic. So this pr introduces a new field in `tile_metadata.json` called `is_valid`. Tiles that are deemed invalid are still rendered as pngs in the tiling directory, but recorded as `is_valid: false` in `tile_metadata.json`.

The annotation_builder also accounts for these by skipping `is_valid: false` tiles in the generation of the coco annotations that go into training.

Also adds a comment on the old default value for `--overlap` so it can be used to regenerate consistent tiles as needed.