### PR TITLE
A few big changes in this pr

### DIFF
--- a/detectron2/README.md
+++ b/detectron2/README.md
@@ -44,7 +44,7 @@ For a quickstart and a brief overview of the pipeline, continue reading. For eve
 	| 
      8. InferenceRunner (docker/remote server)
 	| 
-	| Batch (file) mode 
+	| Single file mode 
 	| - Load metadata from coco 
 	| - Load weights from training 
 	| - Predict polygons 
@@ -63,6 +63,9 @@ For a quickstart and a brief overview of the pipeline, continue reading. For eve
           \--> User uploads image, chooses weights + threshold + classes --> InferenceRunner is invoked per image 
 	---|
 	|
+        | Batch mode
+        | - Invokes single file mode for all files in a given input dir
+        | - Stitches these files together (see post-processing stage) 
 	|
      9. Test scoring 
 	| - Compare test coco w/ prediction coco for test scores 
@@ -74,9 +77,19 @@ For a quickstart and a brief overview of the pipeline, continue reading. For eve
 	| 	Loss curves
 	| 	Ablation
 	|
-     10. Post-processing
+     10. Stitching
+        | - Stitch tiles together to form a mosaic 
+        | - For tiles that are absent in the output dir, replace them with tiles from the input dir 
+        | - Resizes the stitched  mosaic map to a manageable size for the frontend 
+	| - Generates an `inference_tile_metadata.json` with parent child relationships of tiles/mosaics 
+	|
+     11. Offloading 
+        | - Generate signed s3 urls for each entry in `inference_tile_metadata.json`
+	| - Generate an `output_tile_metadata.xlsx` which can be uploaded to the frontend or shared 
+        | 
+     12. Metrics
 	| - Per (site, category, tile) metrics 
-	| ??? (stitch tiles, generate histograms/heatmaps)
+	| ??? (generate histograms/heatmaps)
 ```
 
 - Steps 1-4: Discovery, validation, tiling and COCO annotation transformation
@@ -131,21 +144,35 @@ Set `pipeline_config` to
 There are 2 modes of inference: 
 1. Single image mode 
 2. Through the UI
-3. Batch mode (unimplemented)
+3. Batch mode 
 
-Single image mode 
+### Single image mode 
+
+To run inference against a single image 
 ```
-$ source venv/bin/activate && ./run_inference.sh -image ./data/test/images/Hulibanda_Cleared_plot_1_x7467_y3840.png -output_dir ./inference -weights ./checkpoints/all/model_final.pth 
+$ source venv/bin/activate && ./single_inference.sh -image ./data/test/images/Hulibanda_Cleared_plot_1_x7467_y3840.png -output_dir ./inference -weights ./checkpoints/all/model_final.pth 
 ```
 This will generate 2 images in `./inference`
 1. The base png + predictions 
 2. The base png + annotations taken from `--test_dir`/annotations.json
 
-Or, if you would prefer the gradio interface (same command with `-gradio`)
+### UI (gradio)
+
+If you would prefer the gradio interface (same command with `-gradio`)
 ```
-$ source venv/bin/activate && ./run_inference.sh -image ./data/test/images/Hulibanda_Cleared_plot_1_x7467_y3840.png -output_dir ./inference -weights ./checkpoints/all/model_final.pth -gradio
+$ source venv/bin/activate && ./single_inference.sh -image ./data/test/images/Hulibanda_Cleared_plot_1_x7467_y3840.png -output_dir ./inference -weights ./checkpoints/all/model_final.pth -gradio
 ```
 And modify the confidence level and selected classes appropriately. 
+
+### Batch mode 
+
+Run
+```shell
+./batch_inference.sh -input_dir ./data/test/images/ -output_dir ./inference
+```
+This will
+1. First run inference on all images in the test dir (by invoking `single_inference` on each image) 
+2. Then stitch them together (by again invoking `single_infrence` with the right `pipeline_config`)
 
 ## Data "Discovery" 
 

--- a/detectron2/batch_inference.sh
+++ b/detectron2/batch_inference.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Default values
+weights="./checkpoints/all/model_final.pth"
+classes="Lantana Cover"
+min=""
+output_dir="./inference"
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -input_dir) input_dir="$2"; shift ;;
+        -output_dir) output_dir="$2"; shift ;;
+        -weights) weights="$2"; shift ;;
+        -classes) classes="$2"; shift ;;
+        -min) min="-min" ;;  # just a flag, doesn't take a value
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Check required args
+if [[ -z "$input_dir" || -z "$output_dir" ]]; then
+    echo "Usage: $0 -input_dir <path> -output_dir <path> [-weights <path>] [-classes <class>] [-min]"
+    exit 1
+fi
+
+# Create temporary directory for pipeline config
+tmp_dir=$(mktemp -d)
+pipeline_config="$tmp_dir/pipeline_config.json"
+
+# Function to create pipeline config with inference enabled and stitching disabled
+create_inference_config() {
+    cat > "$pipeline_config" << EOF
+{
+    "skip_validation": true,
+    "skip_tiling": true,
+    "skip_annotation": true,
+    "skip_training": true,
+    "skip_inference": false,
+    "skip_stitching": true
+}
+EOF
+}
+
+# Function to create pipeline config with inference disabled and stitching enabled
+create_stitching_config() {
+    cat > "$pipeline_config" << EOF
+{
+    "skip_validation": true,
+    "skip_tiling": true,
+    "skip_annotation": true,
+    "skip_training": true,
+    "skip_inference": true,
+    "skip_stitching": false
+}
+EOF
+}
+
+# Count total number of images
+total_images=0
+for image_file in "$input_dir"/*.{png,jpg,jpeg,JPG,JPEG,PNG}; do
+    [ -e "$image_file" ] && ((total_images++))
+done
+
+echo "Found $total_images images to process"
+echo "----------------------------------------"
+
+# Step 1: Run inference on all images
+echo "Step 1: Running inference on all images..."
+create_inference_config
+
+current=0
+for image_file in "$input_dir"/*.{png,jpg,jpeg,JPG,JPEG,PNG}; do
+    [ -e "$image_file" ] || continue
+    ((current++))
+    echo "Processing image $current/$total_images: $image_file"
+    ./single_inference.sh -image "$image_file" -output_dir "$output_dir" -weights "$weights" -classes "$classes" -min -pipeline_config "$pipeline_config"
+done
+
+# Step 2: Run stitching once for all images
+echo "----------------------------------------"
+echo "Step 2: Running stitching for all images..."
+create_stitching_config
+./single_inference.sh -output_dir "$output_dir" -weights "$weights" -pipeline_config "$pipeline_config"
+
+# Clean up temporary directory
+rm -rf "$tmp_dir"
+
+echo "----------------------------------------"
+echo "Completed processing all $total_images images"

--- a/detectron2/inference_runner.py
+++ b/detectron2/inference_runner.py
@@ -1,3 +1,17 @@
+"""
+This script is used to run inference on a single image. 
+
+NB: The classes supplied via the --classes argument are used to filter the predictions. You can find class names in the test/annotations.json file, or by running the following command: 
+    python3 ./hack/type_name_combos.py
+
+Usage: 
+    python inference_runner.py --weights_path path/to/weights.pth \
+        --test_dir path/to/test \
+        --output_dir path/to/output \
+        --test_image path/to/image.jpg \
+        --classes "Lantana Cover,Trees" \
+        --minimal_visualization
+"""
 import os
 import cv2
 import json
@@ -45,11 +59,11 @@ class GradioLauncher:
 
             # Get visualization (which returns RGB since it uses matplotlib)
             vis = self.runner.get_visualized_image(
-                image, outputs, selected_classes)
+                image, outputs)
 
             # No need for additional conversion since vis is already in RGB
             json_data = self.runner.get_coco_json(
-                outputs, "gradio_input.jpg", selected_classes)
+                outputs, "gradio_input.jpg")
             return vis, json_data
 
         gr.Interface(
@@ -71,13 +85,12 @@ class GradioLauncher:
 
 
 class InferenceRunner:
-    def __init__(self, weights_path, output_dir, test_dir, confidence_threshold=0.3, test_image=None):
+    def __init__(self, weights_path, output_dir, test_dir, confidence_threshold=0.3, test_image=None, minimal_visualization=False, selected_classes=None):
         self.weights_path = weights_path
         self.output_dir = output_dir
         self.test_dir = test_dir
         self.confidence_threshold = confidence_threshold
         self.test_image = test_image
-
         # Only try to get input_basename if test_image is provided
         if test_image is not None:
             self.input_basename = os.path.basename(test_image)
@@ -103,7 +116,8 @@ class InferenceRunner:
             f"Loaded {len(self.class_names)} classes from {self.test_coco_path}")
 
         self.predictor = DefaultPredictor(self.cfg)
-        self.visualizer = DetectronVisualizer(self.class_names)
+        self.visualizer = DetectronVisualizer(
+            self.class_names, selected_classes, minimal_visualization)
 
     def _get_config(self):
         cfg = get_cfg()
@@ -124,7 +138,8 @@ class InferenceRunner:
         outputs = self.predictor(image)
         self.logger.info(outputs["instances"])
 
-        self.visualizer.draw_predictions(image, outputs, self.output_png)
+        self.visualizer.draw_predictions(
+            image, outputs, self.output_png)
         self.visualizer.save_predictions_json(
             outputs, self.test_image, self.output_json)
         self.logger.info(f"Saved overlay to {self.output_png}")
@@ -133,12 +148,12 @@ class InferenceRunner:
     def predict_image(self, image):
         return self.predictor(image)
 
-    def get_visualized_image(self, image, outputs, selected_classes=None):
-        return self.visualizer.get_overlay(image, outputs, selected_classes)
+    def get_visualized_image(self, image, outputs):
+        return self.visualizer.get_overlay(image, outputs)
 
-    def get_coco_json(self, outputs, image_path, selected_classes=None):
+    def get_coco_json(self, outputs, image_path):
         return self.visualizer.format_predictions_as_json(
-            outputs, image_path, selected_classes)
+            outputs, image_path)
 
 
 def main():
@@ -155,8 +170,18 @@ def main():
                         help="Confidence score threshold for predictions (default: 0.3)")
     parser.add_argument("--gradio_mode", action="store_true",
                         help="Run the Gradio interface instead of the command line interface.")
+    parser.add_argument("--classes", type=str, default=None,
+                        help="Comma-separated list of class names to filter predictions. If not provided, all classes will be shown.")
+    parser.add_argument("--minimal_visualization", action="store_true",
+                        help="Use minimal visualization (no legends, borders, or text).")
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
+
+    # Parse the classes argument if provided
+    selected_classes = None
+    if args.classes:
+        selected_classes = [c.strip() for c in args.classes.split(",")]
+        logging.info(f"Filtering predictions for classes: {selected_classes}")
 
     if args.gradio_mode:
         logging.info("Running in interactive (UI) mode...")
@@ -174,8 +199,11 @@ def main():
             output_dir=args.output_dir,
             test_dir=args.test_dir,
             confidence_threshold=args.confidence_threshold,
-            test_image=args.test_image
+            test_image=args.test_image,
+            minimal_visualization=args.minimal_visualization,
+            selected_classes=selected_classes
         )
+        # Pass selected_classes to run method
         runner.run()
 
 

--- a/detectron2/inference_utils.py
+++ b/detectron2/inference_utils.py
@@ -16,47 +16,92 @@ import tempfile
 class DetectronVisualizer:
     EDGE_COLOR = 'red'
 
-    def __init__(self, class_names):
+    def __init__(self, class_names, selected_classes=None, minimal_visualization=False):
         """Initialize the DetectronVisualizer.
 
         @param output_dir: Directory where visualizations and predictions will be saved
         @param class_names: List of class names corresponding to model predictions
+        @param selected_classes: Optional list of class names to filter
+        @param minimal_visualization: If True, only draws polygons without legends, borders, or text
         """
         self.class_names = class_names
         self.logger = logging.getLogger("visualizer")
+        self.selected_classes = selected_classes
+        self.minimal_visualization = minimal_visualization
 
-    def render_predictions(self, image, outputs, selected_classes=None, save_path=None):
+    def _merge_overlapping_contours(self, contours, image_shape):
+        """Merge overlapping or intersecting contours into a single continuous border.
+
+        @param contours: List of contours to merge
+        @param image_shape: Shape of the image (height, width)
+        @returns: List of merged contours
+        """
+        if not contours:
+            return []
+
+        # Create mask with actual image dimensions
+        height, width = image_shape[:2]
+        combined_mask = np.zeros((height, width), dtype=np.uint8)
+
+        # Draw all contours onto the mask
+        for contour in contours:
+            cv2.drawContours(combined_mask, [contour], -1, 1, -1)
+
+        # Find all contours in the combined mask
+        all_contours, hierarchy = cv2.findContours(
+            combined_mask,
+            cv2.RETR_TREE,  # Use TREE to get parent-child relationships
+            cv2.CHAIN_APPROX_SIMPLE
+        )
+
+        # Filter to keep only the outermost contours
+        outer_contours = []
+        if hierarchy is not None:
+            hierarchy = hierarchy[0]  # Get the first hierarchy level
+            for i, (contour, h) in enumerate(zip(all_contours, hierarchy)):
+                # If this contour has no parent (is outermost) or its parent is -1
+                if h[3] == -1:  # h[3] is the parent index
+                    outer_contours.append(contour)
+        else:
+            # If no hierarchy, use all contours
+            outer_contours = all_contours
+
+        return outer_contours
+
+    def render_predictions(self, image, outputs, save_path=None):
         """
         Render predictions over image as a PNG or return as a NumPy array.
 
         @param image: Input image (OpenCV BGR)
         @param outputs: Detectron2 outputs
-        @param selected_classes: Optional list of class names to filter
         @param save_path: If provided, saves to disk. If None, returns RGB NumPy array
 
         @returns: None if saved to disk, else NumPy RGB image
         """
         image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-        predictions = outputs["instances"].to("cpu")
+        height, width = image.shape[:2]
 
-        fig, ax = plt.subplots(figsize=(10, 10))
+        # Use actual image dimensions
+        dpi = 100
+        fig, ax = plt.subplots(
+            figsize=(width/dpi, height/dpi), dpi=dpi, frameon=False)
+        ax.set_axis_off()
+        plt.subplots_adjust(left=0, right=1, top=1, bottom=0)
+
         ax.imshow(image_rgb)
-        ax.set_title("Predicted Masks")
 
         categories_present = set()
         cmap = plt.colormaps["tab20"]
 
-        # self.logger.info(
-        #     f"Predictions: {len(predictions)} classes: {predictions.pred_classes}\nClass names: {self.class_names}")
+        # Dictionary to store contours by class
+        class_contours = {}
 
+        predictions = outputs["instances"].to("cpu")
         for i in range(len(predictions)):
             class_id = int(predictions.pred_classes[i])
             class_name = self.class_names[class_id]
 
-            # self.logger.info(
-            #     f"Prediction classes: {predictions.pred_classes[i]}\nClass names: {self.class_names}")
-
-            if selected_classes and class_name not in selected_classes:
+            if self.selected_classes and class_name not in self.selected_classes:
                 self.logger.info(
                     f"[render_predictions] skipped class {class_name} because it's not in selected_classes")
                 continue
@@ -72,6 +117,12 @@ class DetectronVisualizer:
                 cv2.CHAIN_APPROX_SIMPLE
             )
 
+            # Store contours for this class
+            if class_id not in class_contours:
+                class_contours[class_id] = []
+            class_contours[class_id].extend(contours)
+
+            # Draw filled polygons
             for contour in contours:
                 polygon = contour[:, 0, :]
                 patch = patches.Polygon(
@@ -84,36 +135,46 @@ class DetectronVisualizer:
                 )
                 ax.add_patch(patch)
 
+                # Only add text (confidence score) if not in minimal mode
+                if not self.minimal_visualization:
+                    centroid = np.mean(polygon, axis=0)
+                    ax.text(centroid[0], centroid[1], f"{score:.2f}",
+                            color='white', fontsize=8,
+                            bbox=dict(facecolor='black', alpha=0.5,
+                                      edgecolor='none', pad=1),
+                            ha='center', va='bottom')
+
+        # Process borders for each class separately
+        for class_id, contours in class_contours.items():
+            color = cmap(class_id * 2)
+            merged_contours = self._merge_overlapping_contours(
+                contours, image.shape)
+            for contour in merged_contours:
+                polygon = contour[:, 0, :]
                 border = patches.Polygon(
                     polygon,
                     closed=True,
-                    edgecolor=self.EDGE_COLOR,
+                    edgecolor=color,  # Use class color for border
                     facecolor='none',
                     alpha=1.0,
-                    linewidth=1.0
+                    linewidth=3.0
                 )
                 ax.add_patch(border)
 
-                centroid = np.mean(polygon, axis=0)
-                ax.text(centroid[0], centroid[1], f"{score:.2f}",
-                        color='white', fontsize=8,
-                        bbox=dict(facecolor='black', alpha=0.5,
-                                  edgecolor='none', pad=1),
-                        ha='center', va='bottom')
-
-        handles = [
-            patches.Patch(color=cmap(cid * 2),
-                          label=self.class_names[cid],
-                          alpha=0.2)
-            for cid in sorted(categories_present)
-        ]
-        ax.legend(handles=handles, bbox_to_anchor=(1.05, 1), loc='upper left')
-        ax.axis('off')
-        plt.tight_layout()
+        # Only add legend if not in minimal mode
+        if not self.minimal_visualization:
+            handles = [
+                patches.Patch(color=cmap(cid * 2),
+                              label=self.class_names[cid],
+                              alpha=0.2)
+                for cid in sorted(categories_present)
+            ]
+            ax.legend(handles=handles, bbox_to_anchor=(
+                1.05, 1), loc='upper left')
+            ax.axis('off')
+            plt.tight_layout()
 
         # Use temporary file if save_path not provided
-        # In both cases, whether gradio rendering or writing to file, we write
-        # to file and read back from file anyway
         temp_file = None
         output_path = save_path
         if not save_path:
@@ -121,21 +182,25 @@ class DetectronVisualizer:
             output_path = temp_file.name
 
         try:
-            plt.savefig(output_path, bbox_inches='tight',
-                        pad_inches=0, format="png")
+            # Save with no padding if minimal visualization
+            if self.minimal_visualization:
+                plt.savefig(output_path, bbox_inches=None,
+                            pad_inches=0, format="png")
+            else:
+                plt.savefig(output_path, bbox_inches='tight',
+                            pad_inches=0, format="png")
             plt.close(fig)
             return cv2.imread(output_path)
         finally:
             if temp_file:
                 temp_file.close()
 
-    def format_predictions(self, outputs, image_path, selected_classes=None, save_path=None):
+    def format_predictions(self, outputs, image_path, save_path=None):
         """
         Format predictions into COCO-style JSON.
 
         @param outputs: Detectron2 outputs
         @param image_path: Original image filename
-        @param selected_classes: Optional list of class names to include
         @param save_path: If provided, writes JSON to disk. Else, returns list.
 
         @returns: None if saved to disk, else list of prediction dicts
@@ -146,7 +211,7 @@ class DetectronVisualizer:
         for i in range(len(predictions)):
             class_id = int(predictions.pred_classes[i])
             class_name = self.class_names[class_id]
-            if selected_classes and class_name not in selected_classes:
+            if self.selected_classes and class_name not in self.selected_classes:
                 self.logger.info(
                     f"[format_predictions] would have skipped class {class_name} because it's not in selected_classes")
 
@@ -180,16 +245,17 @@ class DetectronVisualizer:
             return results
 
     def draw_predictions(self, image, outputs, output_png):
-        self.render_predictions(image, outputs, save_path=output_png)
+        self.render_predictions(
+            image, outputs, save_path=output_png)
 
-    def get_overlay(self, image, outputs, selected_classes=None):
-        return self.render_predictions(image, outputs, selected_classes, save_path=None)
+    def get_overlay(self, image, outputs):
+        return self.render_predictions(image, outputs, save_path=None)
 
     def save_predictions_json(self, outputs, image_path, output_json):
         self.format_predictions(outputs, image_path, save_path=output_json)
 
-    def format_predictions_as_json(self, outputs, image_path, selected_classes=None):
-        return self.format_predictions(outputs, image_path, selected_classes, save_path=None)
+    def format_predictions_as_json(self, outputs, image_path):
+        return self.format_predictions(outputs, image_path, save_path=None)
 
     def draw_coco_annotations(
             self, image_path, coco_path, output_path="coco_overlay.png"):
@@ -291,7 +357,7 @@ class DetectronVisualizer:
             save_path = temp_file.name
 
         try:
-            plt.savefig(save_path, bbox_inches='tight',
+            plt.savefig(save_path, bbox_inches=None,
                         pad_inches=0, format="png")
             plt.close(fig)
             return cv2.imread(save_path)

--- a/detectron2/main.py
+++ b/detectron2/main.py
@@ -67,7 +67,7 @@ def launch_training_in_docker(train_dir, val_dir, output_dir, training_image, fo
     logging.info("Training completed")
 
 
-def launch_inference_in_docker(weights_path, test_image, output_dir, image_name, test_dir, confidence_threshold, gradio_mode):
+def launch_inference_in_docker(weights_path, test_image, output_dir, image_name, test_dir, confidence_threshold, gradio_mode, minimal_visualization, classes):
     client = docker.from_env()
 
     cmd = [
@@ -76,11 +76,16 @@ def launch_inference_in_docker(weights_path, test_image, output_dir, image_name,
         "--test_image", test_image,
         "--output_dir", output_dir,
         "--test_dir", test_dir,
-        "--confidence_threshold", str(confidence_threshold),
+        "--confidence_threshold", str(confidence_threshold)
     ]
 
     if gradio_mode:
         cmd.append("--gradio_mode")
+    if minimal_visualization:
+        cmd.append("--minimal_visualization")
+    if classes:
+        cmd.append("--classes")
+        cmd.append(classes)
 
     container = client.containers.run(
         image=image_name,
@@ -157,6 +162,11 @@ def main():
                         help="Run the Gradio interface instead of the command line interface.")
     parser.add_argument("--pipeline_config", type=str,
                         help="Path to JSON config file controlling pipeline stages")
+    parser.add_argument("--inference_minimal_visualization", action="store_true",
+                        default=False,
+                        help="Use minimal visualization (no legends, borders, or text).")
+    parser.add_argument("--inference_classes", type=str, default=None,
+                        help="Comma-separated list of class names to filter predictions. If not provided, all classes will be shown.")
 
     args = parser.parse_args()
 
@@ -263,7 +273,9 @@ def main():
             args.inference_image,
             args.test_dir,
             args.inference_confidence_threshold,
-            args.inference_gradio_mode
+            args.inference_gradio_mode,
+            args.inference_minimal_visualization,
+            args.inference_classes
         )
     else:
         logging.info("Step 6: Inference (Skipped)")

--- a/detectron2/single_inference.sh
+++ b/detectron2/single_inference.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Check if minimum required arguments are provided
-if [ $# -lt 6 ]; then
-    echo "Usage: $0 -image <image_path> -output_dir <output_directory> -weights <weights_path> [-confidence <threshold> -gradio]"
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 -image <image_path> -output_dir <output_directory> -weights <weights_path> [-confidence <threshold> -gradio -min -classes <class_list> -pipeline_config <config_path>]"
     exit 1
 fi
 
@@ -30,6 +30,18 @@ while [[ $# -gt 0 ]]; do
             GRADIO_MODE="true"
             shift 1
             ;;
+        -min)
+            MINIMAL_VIS="true"
+            shift 1
+            ;;
+        -classes)
+            CLASSES="$2"
+            shift 2
+            ;;
+        -pipeline_config)
+            PIPELINE_CONFIG="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown argument: $1"
             exit 1
@@ -38,10 +50,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Set default confidence if not specified
-CONFIDENCE=${CONFIDENCE:-0.3}
+# TODO(prashanth@): tune this higher, eg 0.3
+CONFIDENCE=${CONFIDENCE:-0.1}
+
+# Set default pipeline config if not specified
+PIPELINE_CONFIG=${PIPELINE_CONFIG:-./pipeline_config.json}
 
 # Check if required arguments are set
-if [ -z "$IMAGE" ] || [ -z "$OUTPUT_DIR" ] || [ -z "$WEIGHTS" ]; then
+if [ -z "$OUTPUT_DIR" ] || [ -z "$WEIGHTS" ]; then
     echo "All arguments (-image, -output_dir, and -weights) must be specified"
     exit 1
 fi
@@ -52,11 +68,14 @@ file_name=$(basename "${IMAGE}")
 # Create output directory if it doesn't exist
 mkdir -p "$OUTPUT_DIR"
 
-if [ -f "${IMAGE}" ]; then
+# Skip COCO annotation overlay in minimal mode
+if [ -z "$MINIMAL_VIS" ] && [ -f "${IMAGE}" ]; then
     python3 ./hack/coco_on_png.py --png "${IMAGE}" \
         --coco ./data/test/annotations.json \
         --output "${OUTPUT_DIR}/${file_name}" 
-else
+elif [ -n "$MINIMAL_VIS" ]; then
+    echo "Skipping coco annotation overlay in minimal mode"
+elif [ ! -f "${IMAGE}" ]; then
     echo "Skipping coco annotation overlay since ${IMAGE} doesn't exist"
 fi
 
@@ -70,7 +89,7 @@ python3 main.py --root_dir ~/rtmp/data/shola/data/ \
     --val_dir ./data/val \
     --train_dir ./data/train \
     --test_dir ./data/test \
-    --pipeline_config ./pipeline_config.json \
+    --pipeline_config "${PIPELINE_CONFIG}" \
     --tile_size 2048 \
     --checkpoint_output_dir ./checkpoints/all \
     --training_image detectron2:1.3 \
@@ -80,4 +99,6 @@ python3 main.py --root_dir ~/rtmp/data/shola/data/ \
     --inference_image detectron2-inference:1.4 \
     --inference_confidence_threshold ${CONFIDENCE} \
     ${GRADIO_MODE:+--inference_gradio_mode} \
+    ${MINIMAL_VIS:+--inference_minimal_visualization} \
+    ${CLASSES:+--inference_classes "${CLASSES}"} \
     --log_level INFO


### PR DESCRIPTION
A. Inference utils is selective about classes and viz

1. Accept a whitelist of classes
2. Accept a -min flag that generates images without legends etc
3. Modify run scripts to tolerate these args

Also changes the default -confidence arg

B. Polygons and borders are stacked and drawn

1. We want one smooth border for all concentric predictions of a given class
2. We want intersecting borders for different classes, using different colors

C. Offloader and tiling (see README.md)
D. Batch mode (see README.md)